### PR TITLE
Update to scanner version 4.5.2.2472

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         dockerfile: 4 
         image-name: sonar-scanner
-        tags: latest 4 4.4 4.4.0 4.4.0.2170
+        tags: latest 4 4.6 4.6.2 4.6.2.2472
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -1,8 +1,8 @@
-FROM philipssoftware/node:12-java
+FROM philipssoftware/node:16-java
 
 LABEL maintainer="Jeroen Knoops <jeroen.knoops@philips.com>"
 
-ENV SONAR_SCANNER_VERSION 4.4.0.2170-linux
+ENV SONAR_SCANNER_VERSION 4.6.2.2472-linux
 
 USER root
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The version numbers are related to the version of sonar-scanner in the image app
 ## [Unreleased]
 
 ### Changed
+- Add version 4.6.2.2472-linux
 - Add version 4.4.0.2170-linux
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The scanner will read the `sonar-project.properties` from your project.
 
 ## Content
 
-The images obviously contain whitesource and java8, but also two other files:
+The images obviously contain sonar, node 16, python 2,3 and java 11, but also two other files:
 
 - `REPO`
 - `TAGS`
@@ -50,7 +50,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/sonar-scanner:4 cat TAGS
-sonar-scanner sonar-scanner:4 sonar-scanner:4.4 sonar-scanner:4.4.0 sonar-scanner:4.4.0.2170
+sonar-scanner sonar-scanner:4 sonar-scanner:4.6 sonar-scanner:4.6.2 sonar-scanner:4.6.2.2472
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `sonar-scanner:4` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -58,7 +58,7 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### sonar-scanner
-- `sonar-scanner`, `sonar-scanner:4`, `sonar-scanner:4.4`, `sonar-scanner:4.4.0`, `sonar-scanner:4.4.0.2170` [4/Dockerfile](4/Dockerfile)
+- `sonar-scanner`, `sonar-scanner:4`, `sonar-scanner:4.6`, `sonar-scanner:4.6.2`, `sonar-scanner:4.6.4.2472` [4/Dockerfile](4/Dockerfile)
 
 ## Why
 


### PR DESCRIPTION
# Main
Upgrade scanner version from 4.4.0.2170 to 4.5.2.2472

Docker images with 4.4.0.2170 are still available

## Additional changes
Node is upgraded to LTS --> node 16.4.2

```
NODE: v16.4.2
JAVA: 11.0.11
Python: 2.7.16
Python 3.7.3
SonarScanner: 4.6.2.2472
```
