### PR TITLE
Fix for scanning typescript projects 

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
 RUN pip install --upgrade pip
 RUN pip install -U setuptools
 RUN pip install -U pylint
+RUN npm install -g typescript
 
 WORKDIR /root
 
@@ -29,6 +30,7 @@ RUN rm sonarscanner.zip
 
 ENV SONAR_RUNNER_HOME=/root/sonar-scanner-$SONAR_SCANNER_VERSION
 ENV PATH $PATH:/root/sonar-scanner-$SONAR_SCANNER_VERSION/bin
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 # The config should be set in the project. See sonar-project.properties as example.
 # COPY sonar-project.properties ./sonar-scanner-$SONAR_SCANNER_VERSION/conf/sonar-scanner.properties


### PR DESCRIPTION
**Overview of the Issue -**  Scanning typescript projects  are failing due to missing npm module  
**Motivation for or Use Case** -  ​I am consuming this image for scanning a typescript project
​
**To Reproduce the Error** - 
1.  Run the docker image like below 
```

	    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
        -v $(Agent.BuildDirectory)/s:/root/src \
        -w /root/src \
        --network="host" \
        --env http_proxy=$(pipeline.http_proxy) \
        --env https_proxy=$(pipeline.https_proxy) \
        --env no_proxy=$(pipeline.no_proxy) \
        philipssoftware/sonar-scanner sonar-scanner \
        -Dsonar.login="$(sonarqube.token)" \
        -Dsonar.host.url="$(pipeline.SonarQube.url)"  \
        -Dsonar.projectKey=$(pipeline.SonarQube.ProjectName) \
        -Dsonar.projectVersion=$(pipeline.version.major).$(pipeline.version.minor).$(Build.BuildId) \
```
2.  You can see the error as below 
```
          
          2021-08-24T17:26:18.2821768Z ERROR: Cannot find module 'typescript'
          2021-08-24T17:26:18.2822806Z Require stack:
          2021-08-24T17:26:18.2823394Z - /root/src/.scannerwork/.sonartmp/eslint-bridge-bundle/package/lib/tsconfig.js
          2021-08-24T17:26:18.2824032Z - /root/src/.scannerwork/.sonartmp/eslint-bridge-bundle/package/lib/server.js
          2021-08-24T17:26:18.2824628Z - /root/src/.scannerwork/.sonartmp/eslint-bridge-bundle/package/bin/server
          2021-08-24T17:26:18.2825074Z ERROR: TypeScript dependency was not found and it is required for analysis.
          2021-08-24T17:26:18.2825805Z ERROR: Install TypeScript in the project directory or use NODE_PATH env. variable to set TypeScript location, if it's located outside of project directory.
          2021-08-24T17:26:18.2826433Z ERROR: Missing TypeScript dependency
          2021-08-24T17:26:18.2826913Z org.sonar.plugins.javascript.eslint.MissingTypeScriptException: Missing TypeScript dependency


```  

**Fix**  - Install typescript globally and also set NODE_PATH to node_modules folder 

