### PR TITLE
Update Dockerfile to install require typescript for sonar scanner

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
 RUN pip install --upgrade pip
 RUN pip install -U setuptools
 RUN pip install -U pylint
-RUN npm install -g typescript
+RUN npm install -g typescript@">=3.2.1 <3.8.0"
 
 WORKDIR /root
 


### PR DESCRIPTION
As part of the PR : - https://github.com/philips-software/docker-sonar-scanner/pull/20 

We added Typescript global dependency for performing Sonar Scanner. 

But Sonar scanner requires typescript  version >=3.2.1 && <3.8.0 , version 4 throws an error since TS sonar scanner cannot perform the check with the typescript 4 

Error log : - 
2021-09-02T09:40:18.5161815Z INFO: 46 source files to be analyzed
2021-09-02T09:40:18.5177020Z INFO: Analyzing 46 files using tsconfig: /root/src/Src/ai-widget/src/.scannerwork/.sonartmp/16640881891685302113.tmp
2021-09-02T09:40:18.5303208Z INFO: Version of TypeScript used during analysis: 4.4.2
2021-09-02T09:40:18.5304136Z WARN: You are using version of TypeScript 4.4.2 which is not officially supported; supported versions >=3.2.1 <3.8.0

